### PR TITLE
Fixed link to Sr Lecturer Aikawa's Homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 _Machine Learning Applications for Remote Language Instruction_ is a project by the
 [MIT Programs in Digital Humanities](https://digitalhumanities.mit.edu) in
-collaboration with our Spring 2021 Faculty Fellow, [Takako Aikawa](https://https://aikawa.mit.edu/),
+collaboration with our Spring 2021 Faculty Fellow, [Takako Aikawa](https://aikawa.mit.edu/),
 Senior Lecturer in Japanese in the Global Languages Department at MIT.


### PR DESCRIPTION
Removed the https typo so the hyperlink property redirects to Sr Lecturer Aikawa's site