### PR TITLE
Updated get_quiz_data view with the new field name

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -163,5 +163,5 @@ def get_quiz_data(request, text_id):
     will be randomly selected and arranged.
     """
     text_obj = Text.objects.get(id=text_id)
-    res = get_quiz_sentences(text_obj.text)
+    res = get_quiz_sentences(text_obj.content)
     return Response(res)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3286,9 +3286,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001181",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz",
-      "integrity": "sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ=="
+      "version": "1.0.30001198",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
+      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Since the database field was updated from `.text` to `.content`, this pull request updates the views that had initially relied on `.text` by replacing each of the occurrences with `.content`.