### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.8'
         architecture: 'x64'
     - name: Install Python packages
       run: |


### PR DESCRIPTION
# Overview 

Updates our GitHub actions configuration file to use Python 3.8 when running the `python_linters` job. The `python_linters` job currently uses Python 3.7, despite the `backend_tests` job and the project as a whole requiring Python 3.8. This hasn't yet caused any issues, but PR #22 installs a package with a 3.8 language requirement, causing the CI job to fail with a "unknown package error."

This PR resolves #23.